### PR TITLE
added support for GCECT

### DIFF
--- a/lib/domains/in/ac/gcect.txt
+++ b/lib/domains/in/ac/gcect.txt
@@ -1,0 +1,1 @@
+Government College of Engineering And Ceramic Technology, Kolkata


### PR DESCRIPTION
added support for Government College of Engineering And Ceramic Technology, Kolkata. Verify at https://www.gcect.ac.in