### PR TITLE
Add url stu.pfisd.net for PFISD High Schools

### DIFF
--- a/lib/domains/net/pfisd/stu.txt
+++ b/lib/domains/net/pfisd/stu.txt
@@ -1,0 +1,1 @@
+Pflugerville Independent School District (Hendrickson, Weiss, Pflugerville, Connally)


### PR DESCRIPTION
Pflugerville Independent School District has the schools Hendrickson, Weiss, Pflugerville, and Connally