### PR TITLE
Add Wilson's School

### DIFF
--- a/lib/domains/uk/sch/sutton/wilsonsschool.txt
+++ b/lib/domains/uk/sch/sutton/wilsonsschool.txt
@@ -1,0 +1,1 @@
+Wilson's School


### PR DESCRIPTION
Added Wilson's School.

Website: wilsons.school
Email Domain: wilsonsschool.sutton.sch.uk
Address:   
  Wilson's School,
  Mollison Dr,
  Wallington,
  SM6 9JW,
  United Kingdom